### PR TITLE
Hinzufügen von Links zurück zur Modulübersicht auf GitHub

### DIFF
--- a/Module/Modul_01.Rmd
+++ b/Module/Modul_01.Rmd
@@ -355,6 +355,8 @@ Die Gefahr solcher Fehlschlüsse verringert sich aber, wenn wir uns darüber Ged
 
 In den folgenden Modulen werden Sie verschiedene datengenerierende Mechanismen kennenlernen und erfahren, wie diese kausale Schlüsse beeinflussen.
 
+<a href="https://github.com/luebby/WWWEKI?tab=readme-ov-file#modul%C3%BCbersicht" class="btn btn-primary">Zur Modulübersicht (auf GitHub)</a>
+
 ## Hinweis
 
 <red> **Dieser Kurs ist aktuell noch in der Entwicklung!** </red>

--- a/Module/Modul_02.Rmd
+++ b/Module/Modul_02.Rmd
@@ -436,6 +436,8 @@ Diese *Kausale Leiter* ist Teil des folgenden Moduls 3.
 Quelle: [https://pixabay.com/vectors/good-girls-cloud-star-ladder-2204244/](Quelle: https://pixabay.com/vectors/good-girls-cloud-star-ladder-2204244/)
 </span>
 
+<a href="https://github.com/luebby/WWWEKI?tab=readme-ov-file#modul%C3%BCbersicht" class="btn btn-primary">Zur Modulübersicht (auf GitHub)</a>
+
 ## Hinweis
 
 <red> **Dieser Kurs ist aktuell noch in der Entwicklung!** </red>

--- a/Module/Modul_03.Rmd
+++ b/Module/Modul_03.Rmd
@@ -196,6 +196,8 @@ question("Sind die Wahrscheinlichkeiten für $y$ bei Assoziation $Pr(y|x)$ und I
          )
 ```
 
+<a href="https://github.com/luebby/WWWEKI?tab=readme-ov-file#modul%C3%BCbersicht" class="btn btn-primary">Zur Modulübersicht (auf GitHub)</a>
+
 ## Hinweis
 
 <red> **Dieser Kurs ist aktuell noch in der Entwicklung!** </red>

--- a/Module/Modul_04.Rmd
+++ b/Module/Modul_04.Rmd
@@ -373,6 +373,8 @@ question("Welcher Wert beschreibt den (totalen) kausalen Effekt von Lernen (`x`)
 Um den (totalen) kausalen Effekt von $X$ auf $Y$ in einer Kette $$X \rightarrow Z \rightarrow Y$$ zu bestimmen, sollte ein Mediator $Z$ **nicht** berücksichtigt werden. Bei fixiertem $Z$ (z.B., wenn die Variable in einer Regression aufgenommen wird) wird der kausale Zusammenhang zwischen $X$ und $Y$ unterbrochen.
 ::: 
 
+<a href="https://github.com/luebby/WWWEKI?tab=readme-ov-file#modul%C3%BCbersicht" class="btn btn-primary">Zur Modulübersicht (auf GitHub)</a>
+
 ## Hinweis
 
 <red> **Dieser Kurs ist aktuell noch in der Entwicklung!** </red>

--- a/Module/Modul_05.Rmd
+++ b/Module/Modul_05.Rmd
@@ -357,6 +357,7 @@ gf_line(x1 ~ zeitpunkte, color = "orange", data = RandomWalk) %>%
 cor.test(x1 ~ x2, data = RandomWalk)
 ```
 
+<a href="https://github.com/luebby/WWWEKI?tab=readme-ov-file#modul%C3%BCbersicht" class="btn btn-primary">Zur Modulübersicht (auf GitHub)</a>
 
 ## Hinweis
 

--- a/Module/Modul_06.Rmd
+++ b/Module/Modul_06.Rmd
@@ -257,6 +257,8 @@ Beispielsweise sollte man in einem linearen Modell nicht $Z$ als erklärende Var
 Man sollte auch nicht die Daten anhand von $Z$ in Gruppen einteilen, die man dann separat analysiert -- auch das verzerrt Zusammenhänge.
 ::: 
 
+<a href="https://github.com/luebby/WWWEKI?tab=readme-ov-file#modul%C3%BCbersicht" class="btn btn-primary">Zur Modulübersicht (auf GitHub)</a>
+
 ## Hinweis
 
 <red> **Dieser Kurs ist aktuell noch in der Entwicklung!** </red>

--- a/Module/Modul_07.Rmd
+++ b/Module/Modul_07.Rmd
@@ -266,7 +266,7 @@ question("Angenommen, wir wollen die erwartete Änderung des Preises, wenn die F
          )
 ```
 
-
+<a href="https://github.com/luebby/WWWEKI?tab=readme-ov-file#modul%C3%BCbersicht" class="btn btn-primary">Zur Modulübersicht (auf GitHub)</a>
 
 ## Hinweis
 

--- a/Module/Modul_08.Rmd
+++ b/Module/Modul_08.Rmd
@@ -595,7 +595,7 @@ In diesem Modul haben Sie statistische Methoden kennengelernt, wie Sie Datenerhe
 Leider gelingt das in der Praxis nicht immer; in manchen Situationen ist es schlicht nicht möglich.
 
 
-
+<a href="https://github.com/luebby/WWWEKI?tab=readme-ov-file#modul%C3%BCbersicht" class="btn btn-primary">Zur Modulübersicht (auf GitHub)</a>
 
 ## Hinweis
 

--- a/Module/Modul_09.Rmd
+++ b/Module/Modul_09.Rmd
@@ -249,6 +249,8 @@ Die Berechnung eines Counterfactuals erfolgt in 3 Schritten:
 3. **Vorhersage:** Verwenden des modifizierten Modells aus 2. und der Verteilung von $U$ aus 1., um den erwarteten Wert des Counterfactuals für $Y$ zu bestimmen.
 ::: 
 
+<a href="https://github.com/luebby/WWWEKI?tab=readme-ov-file#modul%C3%BCbersicht" class="btn btn-primary">Zur Modulübersicht (auf GitHub)</a>
+
 ## Hinweis
 
 <red> **Dieser Kurs ist aktuell noch in der Entwicklung!** </red>

--- a/Module/Modul_10.Rmd
+++ b/Module/Modul_10.Rmd
@@ -303,6 +303,7 @@ Das folgende Vidoeo zeigt eine kurze Einführung in die Bedienung von DAGitty an
 
 ![](https://vimeo.com/666725243){width="75%"}
 
+<a href="https://github.com/luebby/WWWEKI?tab=readme-ov-file#modul%C3%BCbersicht" class="btn btn-primary">Zur Modulübersicht (auf GitHub)</a>
 
 ## Hinweis
 

--- a/Module/Modul_11.Rmd
+++ b/Module/Modul_11.Rmd
@@ -306,7 +306,7 @@ Exemplarische Beispiele für die Auswirkungen von Variablen bietet der ["A Crash
 Hinreichende Adjustment Sets lassen sich praktischerweise algorithmisch bestimmten.
 Wenn Sie beispielsweise den angenommenen kausalen Graphen in [DAGitty](http://dagitty.net/) (siehe Modul 10) zeichnen, dann bestimmt die Software automatisch alle existierenden *minimal sufficient adjustment sets*, also die kleinstmöglichen Adjustment Sets, die ausreichen, um den kausalen Effekt zu identifizieren. 
 
-
+<a href="https://github.com/luebby/WWWEKI?tab=readme-ov-file#modul%C3%BCbersicht" class="btn btn-primary">Zur Modulübersicht (auf GitHub)</a>
 
 ## Hinweis
 

--- a/Module/Modul_12.Rmd
+++ b/Module/Modul_12.Rmd
@@ -343,6 +343,7 @@ Die Idee der Causal Fusion ist, dass wir trotzdem all diese Datenquellen *in Kom
 
 - Paul Hünermund und Elias Bareinboim, [Causal Inference and Data-Fusion in Econometrics](https://arxiv.org/abs/1912.09104v2)
 
+<a href="https://github.com/luebby/WWWEKI?tab=readme-ov-file#modul%C3%BCbersicht" class="btn btn-primary">Zur Modulübersicht (auf GitHub)</a>
 
 ## Hinweis
 


### PR DESCRIPTION
Hallo, hier ein Vorschlag, am Ende der jeweiligen Module zurück zur Modulübersicht auf GitHub zu linken.

Für mehr Kontext und Diskussion, siehe Issue [#4](https://github.com/luebby/WWWEKI/issues/4#issuecomment-2930033133).

Hier ein Beispiel, wie das für Modul 01 aussehen würde:

![beispiel-link](https://github.com/user-attachments/assets/bc87d545-aff9-4fb0-b0db-1c01c1e87bc6)
