### PR TITLE
Ersetzen von gf_lm() durch ggplot-Funktionen, um Warnungen zu vermeiden

### DIFF
--- a/Module/Modul_04.Rmd
+++ b/Module/Modul_04.Rmd
@@ -294,9 +294,10 @@ Ein Verfahren, um Zusammenhänge zwischen Variablen $\color{green}{X}$ und $\col
 Dabei wird angenommen, dass der Zusammenhang zwischen der zu erklärenden Variable $\color{blue}{Y}$ und den weiteren Variablen im Modell linear ist, d. h., es reicht *nur* die jeweiligen Steigungen zu schätzen, um den Zusammenhang zu beschreiben. So sieht es aus, wenn wir in unseren simulierten Daten den Zusammenhang zwischen Lernen und Verstehen berechnen:
 
 ```{r streu, out.width='80%', fig.align='center', echo = FALSE}
-gf_point(y ~ x, data = SimData) %>% # Streudiagramm
-  gf_lm() %>% # Regressionsgerade
-  gf_labs(x = "x: Lernen", y = "y: Verstehen") # Achsenbeschriftung 
+ggplot(SimData, aes(x = x, y = y)) +
+  geom_point() + # Streudiagramm
+  geom_smooth(formula = y ~ x, method = "lm") + # Regressionsgerade
+  labs(x = "x: Lernen", y = "y: Verstehen") # Achsenbeschriftung
 ```
 
 In `R` kann eine lineare Regression über die Funktion `lm()` berechnet werden.

--- a/Module/Modul_05.Rmd
+++ b/Module/Modul_05.Rmd
@@ -97,15 +97,13 @@ Oder etwa doch?
 
 Robert Matthews hat sich Anfang des Jahrtausend die Mühe gemacht Daten für die Fragestellung zu sammeln ([Quelle](https://doi.org/10.1111/1467-9639.00013)):
 
-```{r scatter, echo=FALSE, fig.align='center', out.width='85%', warning=FALSE}
-gf_point(geburten ~ stoerche, data = StoercheGeburten, size = 2, alpha = 0.7) %>%
-  gf_lm() %>%
-  gf_lims(x=c(0,35000), y=c(0,2000000)) %>%
-  gf_text(geburten ~ stoerche,
-          label = ~land,
-          hjust = 0, vjust = 2, alpha = 0.8, size = 7,
-          check_overlap = TRUE) %>%
-  gf_labs(x="Anzahl Störche (Paare)", y="Geburten", caption="Datenquelle: Robert Matthews")
+```{r scatter, echo=FALSE, fig.align='center', out.width='85%'}
+ggplot(StoercheGeburten, aes(x = stoerche, y = geburten)) +
+  geom_point(size = 2, alpha = 0.7) +
+  geom_smooth(formula = y ~ x, method = "lm", se = FALSE) +
+  coord_cartesian(xlim = c(0, 35000), y = c(0, 2000000)) +
+  geom_text(aes(label = land), hjust = 0, vjust = 2, alpha = 0.8, size = 7, check_overlap = TRUE) +
+  labs(x="Anzahl Störche (Paare)", y="Geburten", caption="Datenquelle: Robert Matthews")
 ```
 
 
@@ -177,15 +175,13 @@ Um beliebte Fehlinterpretation des p-Wertes auszuschließen: Das bedeutet nicht,
 Überlegen wir uns mögliche Alternativerklärungen.
 Wie sieht eigentlich der Zusammenhang zwischen der Fläche des Landes und der Anzahl Geburten aus?
 
-```{r scatterflaeche, echo=FALSE, fig.align='center', out.width='85%', warning=FALSE}
-gf_point(geburten ~ flaeche, data = StoercheGeburten, size = 2, alpha = 0.7) %>%
-  gf_lm() %>%
-  gf_lims(x=c(0,900000), y=c(0,2000000)) %>%
-  gf_text(geburten ~ flaeche,
-          label = ~land,
-          hjust = 0, vjust = 2, alpha = 0.8, size = 7,
-          check_overlap = TRUE) %>%
-  gf_labs(x=parse(text = paste0("'Fläche in '",'~ km^2')), y="Geburten", caption="Datenquelle: Robert Matthews")
+```{r scatterflaeche, echo=FALSE, fig.align='center', out.width='85%'}
+ggplot(StoercheGeburten, aes(x = flaeche, y = geburten)) +
+  geom_point(size = 2, alpha = 0.7) +
+  geom_smooth(formula = y ~ x, method = "lm", se = FALSE) +
+  coord_cartesian(xlim = c(0, 900000), ylim = c(0, 2000000)) +
+  geom_text(aes(label = land), hjust = 0, vjust = 2, alpha = 0.8, size = 7, check_overlap = TRUE) +
+  labs(x=parse(text = paste0("'Fläche in '",'~ km^2')), y="Geburten", caption="Datenquelle: Robert Matthews")
 ```
 
 Anscheinend gibt es auch einen Zusammenhang zwischen der Größe eines Landes und der Anzahl Geburten.
@@ -194,15 +190,13 @@ Anscheinend gibt es auch einen Zusammenhang zwischen der Größe eines Landes un
 
 Aber nicht nur die Anzahl der Geburten steht mit der Fläche im Zusammenhang, sondern auch die Anzahl der Störche:
 
-```{r scatterstoerche, echo=FALSE, fig.align='center', out.width='85%', warning=FALSE}
-gf_point(stoerche ~ flaeche, data = StoercheGeburten, size = 2, alpha = 0.7) %>%
-  gf_lm() %>%
-  gf_lims(x=c(0,900000), y=c(0,35000)) %>%
-  gf_text(stoerche ~ flaeche,
-          label = ~land,
-          hjust = 0, vjust = 2, alpha = 0.8, size = 7,
-          check_overlap = TRUE) %>%
-  gf_labs(x=parse(text = paste0("'Fläche in '",'~ km^2')), y="Anzahl Störche (Paare)", caption="Datenquelle: Robert Matthews")
+```{r scatterstoerche, echo=FALSE, fig.align='center', out.width='85%'}
+ggplot(StoercheGeburten, aes(x = flaeche, y = stoerche)) +
+  geom_point(size = 2, alpha = 0.7) +
+  geom_smooth(formula = y ~ x, method = "lm", se = FALSE) +
+  coord_cartesian(xlim = c(0, 900000), ylim = c(0, 35000)) +
+  geom_text(aes(label = land), hjust = 0, vjust = 2, alpha = 0.8, size = 7, check_overlap = TRUE) +
+  labs(x=parse(text = paste0("'Fläche in '",'~ km^2')), y="Anzahl Störche (Paare)", caption="Datenquelle: Robert Matthews")
 ```
 
 ## Confounder

--- a/Module/Modul_06.Rmd
+++ b/Module/Modul_06.Rmd
@@ -188,10 +188,10 @@ Sowohl die mathematische Darstellung als auch der `R` Code sind hier anspruchsvo
 Worauf es in diesem Modul aber ankommt, sind die Daten, die dabei rauskommen:
 
 ```{r scatter, echo=FALSE, fig.align='center', out.width='85%'}
-gf_point(y ~ x, data = SimData, color = ~z) +
-  scale_color_colorblind()  +
-  xlab("x (Nettigkeit)") +
-  ylab("y (Aussehen)")
+ggplot(SimData, aes(x = x, y = y, colour = z)) +
+  geom_point() +
+  scale_color_colorblind() +
+  labs(x = "x (Nettigkeit)", y = "y (Aussehen)", colour = "z (Date)")
 ```
 
 ## Zusammenhänge
@@ -202,11 +202,11 @@ $\color{green}{X}$ ist die Nettigkeit und $\color{blue}{Y}$ das Aussehen.
 Wenn wir, getrennt nach <violet>Date</violet> ($\color{violet}{Z}$), eine lineare Regression von <blue>Aussehen</blue> ($\color{blue}{Y}$) auf <green>Nettigkeit</green> ($\color{green}{X}$) bestimmen, so sehen die Ergebnisse wie folgt aus:
 
 ```{r scatterlm, echo=FALSE, fig.align='center', out.width='85%'}
-gf_point(y ~ x, data = SimData, color = ~z) %>%
-  gf_lm() +
+ggplot(SimData, aes(x = x, y = y, colour = z)) +
+  geom_point() +
+  geom_smooth(formula = y ~ x, method = "lm", se = FALSE) +
   scale_color_colorblind() +
-  xlab("x (Nettigkeit)") +
-  ylab("y (Aussehen)")
+  labs(x = "x (Nettigkeit)", y = "y (Aussehen)", colour = "z (Date)")
 ```
 
 ```{r corb, echo=FALSE}
@@ -227,8 +227,9 @@ Wenn wir <violet>Date</violet> ($\color{violet}{Z}$) berücksichtigen, sehen wir
 Wenn wir uns hingegen den Zusammenhang zwischen $\color{green}{X}$ und $\color{blue}{Y}$ ohne Berücksichtigung von $\color{violet}{Z}$ angucken, erkennen wir, dass die Variablen eigentlich unabhängig sind:
 
 ```{r scatterlmub, echo=FALSE, fig.align='center', out.width='85%'}
-gf_point(y ~ x, data = SimData) %>%
-  gf_lm()
+ggplot(SimData, aes(x = x, y = y)) +
+  geom_point() +
+  geom_smooth(formula = y ~ x, method = "lm", se = FALSE)
 ```
 
 ***

--- a/Module/Modul_07.Rmd
+++ b/Module/Modul_07.Rmd
@@ -79,14 +79,14 @@ Er enthält Daten zu Häusern in Saratoga County, New York, USA, im Jahr 2006.
 
 Schauen wir uns dort den Zusammenhang zwischen Anzahl Zimmer (`rooms`) und Preis (`price`) einmal an:
 
-```{r desi, warning=FALSE}
+```{r desi}
 # Vorbereitungen: Paket und Daten laden
 library(mosaic)
 data(SaratogaHouses)
 
-# Streudiagramm
-gf_point(price ~ rooms, data = SaratogaHouses) %>%
-  gf_lm() # Regressionsgerade ergänzt
+ggplot(SaratogaHouses, aes(x = rooms, y = price)) +
+  geom_point() + # Streudiagramm
+  geom_smooth(formula = y ~ x, method = "lm") # Regressionsgerade ergänzt
 ```
 
 Wir sehen: Je mehr Zimmer, desto höher der Preis im Mittel.


### PR DESCRIPTION
In diesem PR werden alle `gf_lm()`-Funktionen durch `ggplot`-Funktionen ersetzt, um störende Warnungen zu vermeiden, siehe Issue #9.

Zwei weitere Mini-Änderungen nebenbei:

- In den manchen der betreffenden Codezellen-Einstellungen habe ich auch `warnings=FALSE` gelöscht, was wohl vorher verwendet wurde, um Warnungen zu unterdrücken.
- Ich habe eine Beschriftung für Variable "z (Date)" in Modul 06 ergänzt, die es vorher nicht gab.