### PR TITLE
Klammer schließen in Beispiel-Code

### DIFF
--- a/Module/Modul_04.Rmd
+++ b/Module/Modul_04.Rmd
@@ -276,7 +276,7 @@ f_Y <- function(z) 3 * z + rnorm(length(z))
 n <- 100 # Anzahl Beobachtungen
 SimData <- tibble(x = U_X(n)) %>%
   mutate(z = f_Z(x)) %>%
-  mutate(y = f_Y(z)
+  mutate(y = f_Y(z))
 ```
 
 ## Lineare Regression, Versuch 1


### PR DESCRIPTION
Im Beispielcode (der nicht automatisch ausgeführt wird) fehlt einer Klammer. Falls jemand den Code kopieren und ausführen wollte, würde das auffallen und ggf. verwirren, also hier die Korrektur.
